### PR TITLE
kmod-amneziawg: add new package

### DIFF
--- a/net/kmod-amneziawg/Makefile
+++ b/net/kmod-amneziawg/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=kmod-amneziawg
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-linux-kernel-module.git
+PKG_MIRROR_HASH:=a510149778f2c465806e32583078f76657ba90af43abecbd170df2f6e4d8d4f5
+PKG_SOURCE_VERSION:=b91fabacfa5ef75ecf82d9c6fbf1df83fb403b57
+
+MAKE_PATH:=src
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/amneziawg
+	SECTION:=kernel
+	CATEGORY:=Kernel modules
+	SUBMENU:=Network Support
+	URL:=https://amnezia.org/
+	MAINTAINER:=Gregory Gullin <garuwex@gmail.com>
+	TITLE:=AmneziaWG Kernel Module
+	FILES:=$(PKG_BUILD_DIR)/$(MAKE_PATH)/generated/amneziawg.ko
+	DEPENDS:= \
+		+kmod-udptunnel4 \
+		+IPV6:kmod-udptunnel6 \
+		+kmod-crypto-kpp \
+		+kmod-crypto-lib-chacha20poly1305 \
+		+kmod-crypto-lib-curve25519
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	mkdir -p $(PKG_BUILD_DIR)/$(MAKE_PATH)/kernel
+	$(CP) $(LINUX_DIR)/* $(PKG_BUILD_DIR)/$(MAKE_PATH)/kernel/
+endef
+
+define Build/Compile
+	$(MAKE_VARS) $(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) $(MAKE_FLAGS) apply-patches
+	$(MAKE_VARS) $(MAKE) -C "$(LINUX_DIR)" $(KERNEL_MAKE_FLAGS) M="$(PKG_BUILD_DIR)/$(MAKE_PATH)/generated" EXTRA_CFLAGS="$(BUILDFLAGS)" modules
+endef
+
+$(eval $(call KernelPackage,amneziawg))


### PR DESCRIPTION
This adds support for the AmneziaWG Linux kernel module

https://github.com/amnezia-vpn/amneziawg-linux-kernel-module

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
